### PR TITLE
Convert to plugin format with a standalone script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,33 @@
 # Kubecolor
 
-Kubecolor is a bash function that colorizes the output of `kubectl get events -w`
+Kubecolor is a `bash` function that colorizes the output of `kubectl get events -w`
 
-To install, just run the following commands:
+## Installing
 
-```bash
-curl -k https://raw.githubusercontent.com/droctothorpe/kubecolor/master/.kubecolor -o ~/.kubecolor
-echo "source ~/.kubecolor" >> ~/.bash_profile
-source ~/.bash_profile
-```
+### Bash / Manual Installation
 
-These commands simply copy **.kubecolor** to your home directory and source it in your bash_profile.
+Nothing here requires you to use ZSH as your shell or a ZSH framework,  that's just a convenient distribution method.
+
+If you aren't using any ZSH frameworks, or if you're using `bash`, `fish` or another shell, do the following steps:
+
+1. `git clone` this repository
+2. Add `cloneDirectory/bin` to your `$PATH` if you aren't using `bash`, or add `source /path/to/checkoutDirectory/kubecolor.bash` to your `.bashrc` if you are.
+
+### Antigen
+
+If you're using [Antigen](https://github.com/zsh-users/antigen):
+
+1. Add `antigen bundle droctothorpe/kubecolor.git` to your `.zshrc` where you've listed your other plugins.
+2. Close and reopen your Terminal/iTerm window to **refresh context** and use the plugin. Alternatively, you can run `antigen bundle droctothorpe/kubecolor.git` in a running shell to have `antigen` load the new plugin.
+
+### zgen
+
+If you're using [zgen](https://github.com/tarjoilija/zgen):
+
+1. Add `zgen load droctothorpe/kubecolor.git` to your `.zshrc` along with your other `zgen load` commands.
+2. `zgen reset && zgen save`
+
+## Usage
 
 Now you can invoke kubecolor with the `events` command.
 

--- a/bin/events
+++ b/bin/events
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 events() {
     kubectl get events --all-namespaces --watch \
     -o 'go-template={{.lastTimestamp}} ^ {{.involvedObject.kind}} ^ {{.message}} ^ ({{.involvedObject.name}}){{"\n"}}' \
@@ -17,3 +19,5 @@ events() {
     }
     1'
 }
+
+events

--- a/kubecolor.bash
+++ b/kubecolor.bash
@@ -1,0 +1,6 @@
+# Add plugin's bin diretory to user's path
+PLUGIN_D=$(dirname "$BASH_SOURCE")
+if [[ -d "${PLUGIN_D}/bin" ]]; then
+  export PATH="${PATH}:${PLUGIN_D}/bin"
+fi
+unset PLUGIN_D

--- a/kubecolor.plugin.zsh
+++ b/kubecolor.plugin.zsh
@@ -1,0 +1,6 @@
+# Add plugin's bin diretory to user's path
+PLUGIN_D=$(dirname "$0")
+if [[ -d "${PLUGIN_D}/bin" ]]; then
+  export PATH="${PATH}:${PLUGIN_D}/bin"
+fi
+unset PLUGIN_D


### PR DESCRIPTION
Convert to plugin format with a standalone script.

This makes it easy to use no matter what shell someone is using.

If they're using a modern ZSH framework, those almost all handle `git` cloning the repository for the user and keeping it up to date.

* Added `kubecolor.plugin.zsh` - this will be automatically sourced by frameworks like Antigen and zgen. It is compatible with `bash`.
* Added `kubecolor.bash` - adds bindir to `$PATH`
* Moved events function to bin/events as a standalone script
* Updated install instructions:
  * Updated instructions for `bash` and other shells
  * Added instructions for two common ZSH framework systems